### PR TITLE
Make compatible with runtime-only build of Vue

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -2,8 +2,13 @@ const CSSOM = require('cssom')
 const myClassName = 'simple-svg'
 
 let SimpleSVG = {
-  template:
-    '<div class="simple-svg-wrapper"></div>',
+  render (createElement) {
+    return createElement('div', {
+      'class': [
+        'simple-svg-wrapper'
+      ]
+    })
+  },
   name: 'simple-svg',
   props: {
     filepath: String,


### PR DESCRIPTION
Using the `template:` property requires the full runtime+compiler build.